### PR TITLE
Fix crasher for missing switch config

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ AlmondPlatform.prototype.addAccessory = function(device) {
 
     this.log("Got device: %s [%s]", device.name, device.id)
 
-    if (device.props.SwitchBinary !== undefined) {
+    if (device.props && device.props.SwitchBinary !== undefined) {
         services.push(Service.Switch);
     }
 


### PR DESCRIPTION
Fix crashing bug for instances where switches have no configuration defined